### PR TITLE
Fix build with digestive-functors-0.8.1.0

### DIFF
--- a/digestive-functors-lucid.cabal
+++ b/digestive-functors-lucid.cabal
@@ -1,5 +1,5 @@
 Name:          digestive-functors-lucid
-Version:       0.0.0.3
+Version:       0.0.0.4
 Synopsis:      Lucid frontend for the digestive-functors library
 Description:   Ludic frontend for the digestive-functors library
 Homepage:      https://github.com/athanclark/digestive-functors-lucid

--- a/src/Text/Digestive/Lucid/Html5.hs
+++ b/src/Text/Digestive/Lucid/Html5.hs
@@ -24,7 +24,6 @@ module Text.Digestive.Lucid.Html5
 
 --------------------------------------------------------------------------------
 import           Control.Monad               (forM_, when)
-import           Data.Maybe                  (fromMaybe)
 import           Data.Text                   (Text, pack)
 import           Lucid
 
@@ -142,11 +141,9 @@ inputFile ref view = input_
     [ type_  "file"
     , id_    ref'
     , name_  ref'
-    , value_ $ pack value
     ]
   where
     ref'  = absoluteRef ref view
-    value = fromMaybe "" $ fieldInputFile ref view
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes `digestive-functors-lucid` compliant to the new `digestive-functors'` API, which introduced a breaking change in https://github.com/jaspervdj/digestive-functors/commit/68ff0c7770482011b48e81878e623070f85e63db.

I took the same approach as in https://github.com/jaspervdj/digestive-functors/commit/64e8bce9407ec840fd82c09b8c4d119e78989a0b.
