### PR TITLE
Add inputSelectGroup and generic inputWithType

### DIFF
--- a/src/Text/Digestive/Lucid/Html5.hs
+++ b/src/Text/Digestive/Lucid/Html5.hs
@@ -10,10 +10,12 @@ module Text.Digestive.Lucid.Html5
     , inputPassword
     , inputHidden
     , inputSelect
+    , inputSelectGroup
     , inputRadio
     , inputCheckbox
     , inputFile
     , inputSubmit
+    , inputWithType
     , label
     , form
     , errorList
@@ -38,14 +40,7 @@ ifSingleton True  a = [a]
 
 --------------------------------------------------------------------------------
 inputText :: Monad m => Text -> View v -> HtmlT m ()
-inputText ref view = input_
-    [ type_    "text"
-    , id_      ref'
-    , name_    ref'
-    , value_ $ fieldInputText ref view
-    ]
-  where
-    ref' = absoluteRef ref view
+inputText = inputWithType "text" []
 
 
 --------------------------------------------------------------------------------
@@ -70,26 +65,12 @@ inputTextArea r c ref view = textarea_
 
 --------------------------------------------------------------------------------
 inputPassword :: Monad m => Text -> View v -> HtmlT m ()
-inputPassword ref view = input_
-    [ type_    "password"
-    , id_      ref'
-    , name_    ref'
-    , value_ $ fieldInputText ref view
-    ]
-  where
-    ref' = absoluteRef ref view
+inputPassword = inputWithType "password" []
 
 
 --------------------------------------------------------------------------------
 inputHidden :: Monad m => Text -> View v -> HtmlT m ()
-inputHidden ref view = input_
-    [ type_    "hidden"
-    , id_      ref'
-    , name_    ref'
-    , value_ $ fieldInputText ref view
-    ]
-  where
-    ref' = absoluteRef ref view
+inputHidden = inputWithType "hidden" []
 
 
 --------------------------------------------------------------------------------
@@ -103,6 +84,45 @@ inputSelect ref view = select_
     ref'    = absoluteRef ref view
     value i = ref' `mappend` "." `mappend` i
     choices = fieldInputChoice ref view
+
+
+-------------------------------------------------------------------------------
+-- | Creates a grouped select field using optgroup
+inputSelectGroup :: Monad m => Text -> View (Lucid.HtmlT m ()) -> HtmlT m ()
+inputSelectGroup ref view = Lucid.select_
+    [ id_   ref'
+    , name_ ref'
+    ] $ forM_ choices $ \(groupName, subChoices) -> optgroup_ [label_ groupName] $
+          forM_ subChoices $ \(i, c, sel) -> option_
+          (value_ (value i) : ifSingleton sel (selected_ "selected")) c
+  where
+    ref'    = absoluteRef ref view
+    value i = ref' `mappend` "." `mappend` i
+    choices = fieldInputChoiceGroup ref view
+
+
+-------------------------------------------------------------------------------
+-- | More generic textual input field to support newer input types
+-- like range, date, email, etc.
+inputWithType
+    :: Monad m
+    => Text
+    -- ^ Type
+    -> [Attribute]
+    -- ^ Additional attributes
+    -> Text
+    -> View v
+    -> HtmlT m ()
+inputWithType ty additionalAttrs ref view = input_ attrs
+  where
+    ref' = absoluteRef ref view
+    attrs = defAttrs `mappend` additionalAttrs
+    defAttrs =
+      [ type_ ty
+      , id_ ref'
+      , name_ ref'
+      , value_ $ fieldInputText ref view
+      ]
 
 
 --------------------------------------------------------------------------------
@@ -125,11 +145,10 @@ inputRadio brs ref view = forM_ choices $ \(i, c, sel) -> do
 
 --------------------------------------------------------------------------------
 inputCheckbox :: Monad m => Text -> View (HtmlT m ()) -> HtmlT m ()
-inputCheckbox ref view = input_ $
-    [ type_ "checkbox"
-    , id_   ref'
-    , name_ ref'
-    ] ++ ifSingleton selected checked_
+inputCheckbox ref view = inputWithType "checkbox"
+    (ifSingleton selected checked_)
+    ref
+    view
   where
     ref'     = absoluteRef ref view
     selected = fieldInputBool ref view

--- a/src/Text/Digestive/Lucid/Html5.hs
+++ b/src/Text/Digestive/Lucid/Html5.hs
@@ -145,10 +145,11 @@ inputRadio brs ref view = forM_ choices $ \(i, c, sel) -> do
 
 --------------------------------------------------------------------------------
 inputCheckbox :: Monad m => Text -> View (HtmlT m ()) -> HtmlT m ()
-inputCheckbox ref view = inputWithType "checkbox"
-    (ifSingleton selected checked_)
-    ref
-    view
+inputCheckbox ref view = input_ $
+    [ type_ "checkbox"
+    , id_   ref'
+    , name_ ref'
+    ] ++ ifSingleton selected checked_
   where
     ref'     = absoluteRef ref view
     selected = fieldInputBool ref view


### PR DESCRIPTION
inputSelectGroup is just like inputSelect but when you specify grouped
choices in the digestive-functors side, it creates optgroups in the
resulting input.

inputWithType is something that I ended up using to support some of
the more fancy HTML5 input types without having to write a specialized
input for each one, and you can see I actually rewrote a couple of the
existing inputs in terms of this more generic version. A good example
of this is the user can easily create an email input, telephone number
input, range input, etc without having to necessarily extend the
library itself.